### PR TITLE
Deprecate mixture_channel in favor of just mixture (#3026)

### DIFF
--- a/cirq/ops/common_channels_test.py
+++ b/cirq/ops/common_channels_test.py
@@ -58,7 +58,7 @@ def test_asymmetric_depolarizing_mixture():
                            (0.1, X),
                            (0.2, Y),
                            (0.3, Z)))
-    assert cirq.has_mixture_channel(d)
+    assert cirq.has_mixture(d)
 
 
 def test_asymmetric_depolarizing_channel_repr():
@@ -131,7 +131,7 @@ def test_depolarizing_mixture():
                            (0.1, X),
                            (0.1, Y),
                            (0.1, Z)))
-    assert cirq.has_mixture_channel(d)
+    assert cirq.has_mixture(d)
 
 
 def test_depolarizing_channel_repr():
@@ -176,7 +176,8 @@ def test_generalized_amplitude_damping_channel():
                np.sqrt(0.9) * np.array([[np.sqrt(1. - 0.3), 0.], [0., 1.]]),
                np.sqrt(0.9) * np.array([[0., 0.], [np.sqrt(0.3), 0.]])))
     assert cirq.has_channel(d)
-    assert not cirq.has_mixture_channel(d)
+    assert not cirq.has_mixture(d)
+
 
 def test_generalized_amplitude_damping_repr():
     cirq.testing.assert_equivalent_repr(
@@ -233,7 +234,7 @@ def test_amplitude_damping_channel():
                               (np.array([[1., 0.], [0., np.sqrt(1. - 0.3)]]),
                                np.array([[0., np.sqrt(0.3)], [0., 0.]])))
     assert cirq.has_channel(d)
-    assert not cirq.has_mixture_channel(d)
+    assert not cirq.has_mixture(d)
 
 
 def test_amplitude_damping_channel_repr():
@@ -278,7 +279,7 @@ def test_reset_channel():
         cirq.channel(r),
         (np.array([[1., 0.], [0., 0]]), np.array([[0., 1.], [0., 0.]])))
     assert cirq.has_channel(r)
-    assert not cirq.has_mixture_channel(r)
+    assert not cirq.has_mixture(r)
     assert cirq.qid_shape(r) == (2,)
 
     r = cirq.reset(cirq.LineQid(0, dimension=3))
@@ -288,7 +289,7 @@ def test_reset_channel():
          np.array([[0, 1, 0], [0, 0, 0], [0, 0, 0]]),
          np.array([[0, 0, 1], [0, 0, 0], [0, 0, 0]])))  # yapf: disable
     assert cirq.has_channel(r)
-    assert not cirq.has_mixture_channel(r)
+    assert not cirq.has_mixture(r)
     assert cirq.qid_shape(r) == (3,)
 
 
@@ -351,7 +352,7 @@ def test_phase_damping_channel():
                               (np.array([[1.0, 0.], [0., np.sqrt(1 - 0.3)]]),
                                np.array([[0., 0.], [0., np.sqrt(0.3)]])))
     assert cirq.has_channel(d)
-    assert not cirq.has_mixture_channel(d)
+    assert not cirq.has_mixture(d)
 
 
 def test_phase_damping_channel_repr():
@@ -401,7 +402,7 @@ def test_phase_flip_channel():
 def test_phase_flip_mixture():
     d = cirq.phase_flip(0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.7, np.eye(2)), (0.3, Z)))
-    assert cirq.has_mixture_channel(d)
+    assert cirq.has_mixture(d)
 
 
 def test_phase_flip_overload():
@@ -458,7 +459,7 @@ def test_bit_flip_channel():
 def test_bit_flip_mixture():
     d = cirq.bit_flip(0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.7, np.eye(2)), (0.3, X)))
-    assert cirq.has_mixture_channel(d)
+    assert cirq.has_mixture(d)
 
 
 def test_bit_flip_overload():

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -266,8 +266,11 @@ def test_mixture():
     assert_mixtures_equal(cirq.mixture(op), cirq.mixture(op.gate))
     assert cirq.has_mixture(op)
 
-    assert cirq.mixture(cirq.X(a), None) is None
-    assert not cirq.has_mixture(cirq.X(a))
+    assert cirq.has_mixture(cirq.X(a))
+    m = cirq.mixture(cirq.X(a))
+    assert len(m) == 1
+    assert m[0][0] == 1
+    np.testing.assert_allclose(m[0][1], cirq.unitary(cirq.X))
 
 
 def test_repr():

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -20,7 +20,7 @@ from typing import Any, Sequence, Tuple, TypeVar, Union
 import numpy as np
 from typing_extensions import Protocol
 
-from cirq.protocols.mixture_protocol import has_mixture_channel
+from cirq.protocols.mixture_protocol import has_mixture
 
 
 from cirq.type_workarounds import NotImplementedType
@@ -169,7 +169,7 @@ def has_channel(val: Any) -> bool:
     if result is not NotImplemented:
         return result
 
-    result = has_mixture_channel(val)
+    result = has_mixture(val)
     if result is not NotImplemented and result:
         return result
 

--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -136,8 +136,10 @@ class Simulator(simulator.SimulatesSamples,
         self._check_all_resolved(resolved_circuit)
 
         def measure_or_mixture(op):
-            return protocols.is_measurement(op) or protocols.has_mixture(op)
-        if circuit.are_all_matches_terminal(measure_or_mixture):
+            return not protocols.has_unitary(op) and (
+                protocols.is_measurement(op) or protocols.has_mixture(op))
+
+        if resolved_circuit.are_all_matches_terminal(measure_or_mixture):
             return self._run_sweep_terminal_sample(resolved_circuit,
                                                    repetitions)
         return self._run_sweep_repeat(resolved_circuit, repetitions)

--- a/docs/noise.ipynb
+++ b/docs/noise.ipynb
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### cirq.mixture, cirq.mixture_channel, and def _mixture_\n",
+    "#### cirq.mixture and def _mixture_\n",
     "\n",
     "Some channels can be interpreted as probabilistically selecting between\n",
     "different unitary evolutions:\n",
@@ -77,7 +77,7 @@
     "\n",
     "The first element of each tuple is the probability of the unitary, and the second element is the unitary. Like the `_channel_` method described above, the basis for these matrices is implicit with respect to the object being called. One should also make `_has_mixture_` return `True` to indicate to callers that the object supports the mixture protocol. \n",
     "\n",
-    "If one wants to get the mixture channel directly, one can call `cirq.mixture_channel`.\n"
+    "If one wants to get the mixture channel directly, one can call `cirq.mixture`.\n"
    ]
   },
   {


### PR DESCRIPTION
- mixture's behavior now matches what mixture_channel used to do (i.e. unitary objects have implicit mixtures)